### PR TITLE
Improve test env defaults and add pytest-django

### DIFF
--- a/bnpl_backend/bnpl_backend_project/settings.py
+++ b/bnpl_backend/bnpl_backend_project/settings.py
@@ -10,7 +10,10 @@ load_dotenv()
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
+# Provide a fallback secret key so tests can run without needing
+# environment variables configured. This should be overridden in
+# production via the DJANGO_SECRET_KEY environment variable.
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY', 'test-secret-key')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DJANGO_DEBUG') == 'True'
@@ -73,16 +76,25 @@ WSGI_APPLICATION = 'bnpl_backend_project.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('POSTGRES_DB', 'bnpl'),
-        'USER': os.getenv('POSTGRES_USER', 'bnpl'),
-        'PASSWORD': os.getenv('POSTGRES_PASSWORD', 'bnpl'),
-        'HOST': os.getenv('POSTGRES_HOST', 'db'),
-        'PORT': os.getenv('POSTGRES_PORT', '5432'),
+POSTGRES_HOST = os.getenv('POSTGRES_HOST')
+if POSTGRES_HOST:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': os.getenv('POSTGRES_DB', 'bnpl'),
+            'USER': os.getenv('POSTGRES_USER', 'bnpl'),
+            'PASSWORD': os.getenv('POSTGRES_PASSWORD', 'bnpl'),
+            'HOST': POSTGRES_HOST,
+            'PORT': os.getenv('POSTGRES_PORT', '5432'),
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        }
+    }
 
 # Celery
 REDIS_URL = os.getenv('REDIS_URL')

--- a/bnpl_backend/requirements-dev.txt
+++ b/bnpl_backend/requirements-dev.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-django~=4.11

--- a/bnpl_backend/requirements.txt
+++ b/bnpl_backend/requirements.txt
@@ -33,5 +33,5 @@ uritemplate==4.1.1
 vine==5.1.0
 wcwidth==0.2.13
 gunicorn
-
 pytest~=8.3.5
+pytest-django~=4.11


### PR DESCRIPTION
## Summary
- allow running backend tests without env vars by defaulting SECRET_KEY and DB
- add `pytest-django` to requirements
- choose sqlite when Postgres variables are absent

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e81209da88325b5f8be96e9cbae30